### PR TITLE
Settings for publishing projects publically

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,13 @@
+   Copyright 2017 DC/OS
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-   Copyright 2017 DC/OS
+   Copyright 2017 Mesosphere, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/build.sbt
+++ b/build.sbt
@@ -1,45 +1,36 @@
-name := "sbt-dcos"
+import com.mesosphere.sbt.BuildPlugin.publishSettings
 
-version := "0.1.0-SNAPSHOT"
-
-organization := "com.mesosphere"
-
-sbtPlugin := true
-
-publishMavenStyle := true
-
-pomIncludeRepository := { _ => false }
-
-publishTo := {
-  val nexus = "https://oss.sonatype.org/"
-  if (isSnapshot.value) {
-    Some("snapshots" at nexus + "content/repositories/snapshots")
-  } else {
-    Some("releases" at nexus + "service/local/staging/deploy/maven2")
-  }
-}
-
-pomExtra :=
-  <url>https://dcos.io</url>
-  <licenses>
-    <license>
-      <name>Apache License Version 2.0</name>
-      <url>https://github.com/dcos/sbt-dcos/blob/master/LICENSE</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
-  <scm>
-    <url>https://github.com/dcos/sbt-dcos.git</url>
-    <connection>scm:git:https://github.com/dcos/sbt-dcos.git</connection>
-  </scm>
-  <developers>
-    <developer>
-      <name>Charles Ruhland</name>
-    </developer>
-    <developer>
-      <name>Jesus Larios Murillo</name>
-    </developer>
-    <developer>
-      <name>José Armando García Sancio</name>
-    </developer>
-  </developers>
+lazy val root = project.in(file("."))
+  .settings(
+    name := "sbt-dcos",
+    version := "0.1.0-SNAPSHOT",
+    organization := "com.mesosphere",
+    sbtPlugin := true
+  )
+  .settings(publishSettings)
+  .settings(
+    pomExtra :=
+      <url>https://dcos.io</url>
+      <licenses>
+        <license>
+          <name>Apache License Version 2.0</name>
+          <url>https://github.com/dcos/sbt-dcos/blob/master/LICENSE</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+      <scm>
+        <url>https://github.com/dcos/sbt-dcos.git</url>
+        <connection>scm:git:https://github.com/dcos/sbt-dcos.git</connection>
+      </scm>
+      <developers>
+        <developer>
+          <name>Charles Ruhland</name>
+        </developer>
+        <developer>
+          <name>Jesus Larios Murillo</name>
+        </developer>
+        <developer>
+          <name>José Armando García Sancio</name>
+        </developer>
+      </developers>
+  )

--- a/build.sbt
+++ b/build.sbt
@@ -5,3 +5,41 @@ version := "0.1.0-SNAPSHOT"
 organization := "com.mesosphere"
 
 sbtPlugin := true
+
+publishMavenStyle := true
+
+pomIncludeRepository := { _ => false }
+
+publishTo := {
+  val nexus = "https://oss.sonatype.org/"
+  if (isSnapshot.value) {
+    Some("snapshots" at nexus + "content/repositories/snapshots")
+  } else {
+    Some("releases" at nexus + "service/local/staging/deploy/maven2")
+  }
+}
+
+pomExtra :=
+  <url>https://dcos.io</url>
+  <licenses>
+    <license>
+      <name>Apache License Version 2.0</name>
+      <url>https://github.com/dcos/sbt-dcos/blob/master/LICENSE</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <scm>
+    <url>https://github.com/dcos/sbt-dcos.git</url>
+    <connection>scm:git:https://github.com/dcos/sbt-dcos.git</connection>
+  </scm>
+  <developers>
+    <developer>
+      <name>Charles Ruhland</name>
+    </developer>
+    <developer>
+      <name>Jesus Larios Murillo</name>
+    </developer>
+    <developer>
+      <name>José Armando García Sancio</name>
+    </developer>
+  </developers>

--- a/src/main/scala/com/mesosphere/sbt/BuildPlugin.scala
+++ b/src/main/scala/com/mesosphere/sbt/BuildPlugin.scala
@@ -47,4 +47,17 @@ object BuildPlugin extends AutoPlugin {
     scalacOptions in (Compile, doc) += "-no-link-warnings"
   )
 
+  val publishSettings: Seq[Def.Setting[_]] = Seq(
+    publishMavenStyle := true,
+    pomIncludeRepository := { _ => false },
+    publishTo := {
+      val nexus = "https://oss.sonatype.org/"
+      if (isSnapshot.value) {
+        Some("snapshots" at nexus + "content/repositories/snapshots")
+      } else {
+        Some("releases" at nexus + "service/local/staging/deploy/maven2")
+      }
+    }
+  )
+
 }


### PR DESCRIPTION
Add publishing settings to the plugin. They are not added to builds automatically. Since this plugin itself must be published, its `build.sbt` is an example of how to use the settings.