### PR TITLE
Enable configuration of the integration test classpath

### DIFF
--- a/src/main/scala/com/mesosphere/cosmos/CosmosIntegrationTestServer.scala
+++ b/src/main/scala/com/mesosphere/cosmos/CosmosIntegrationTestServer.scala
@@ -15,7 +15,7 @@ import scala.util.Random
 
 final class CosmosIntegrationTestServer(
   javaHome: Option[String],
-  itResourceDirs: Seq[File],
+  classpathPrefix: Seq[File],
   oneJarPath: File
 ) {
   private val originalProperties: Properties = System.getProperties
@@ -81,7 +81,7 @@ final class CosmosIntegrationTestServer(
 
     val pathSeparator = System.getProperty("path.separator")
     val classpath =
-      s"${itResourceDirs.map(_.getCanonicalPath).mkString("", pathSeparator, pathSeparator)}" +
+      s"${classpathPrefix.map(_.getCanonicalPath).mkString("", pathSeparator, pathSeparator)}" +
         s"${oneJarPath.getCanonicalPath}"
 
     Seq(


### PR DESCRIPTION
This will allow the `default-repositories.json` of the `cosmos-integration-tests` JAR to be used in other projects that run those tests.

This change breaks the API of the plugin. When it is merged, the Cosmos build will be broken until a fix is implemented (I have one pending, so it wouldn't be for very long). If we'd rather not deal with that, I could keep the old `itSettings` method around and have it delegate to the new methods.