### PR TITLE
Remove storage flags

### DIFF
--- a/src/main/scala/com/mesosphere/cosmos/CosmosIntegrationTestServer.scala
+++ b/src/main/scala/com/mesosphere/cosmos/CosmosIntegrationTestServer.scala
@@ -16,7 +16,8 @@ import scala.util.Random
 final class CosmosIntegrationTestServer(
   javaHome: Option[String],
   classpathPrefix: Seq[File],
-  oneJarPath: File
+  oneJarPath: File,
+  additionalProperties: List[TestProperty]
 ) {
   private val originalProperties: Properties = System.getProperties
   private var process: Option[Process] = None           // scalastyle:ignore var.field
@@ -69,15 +70,17 @@ final class CosmosIntegrationTestServer(
       .getOrElse("java")
 
     val dcosUri = systemProperty("com.mesosphere.cosmos.dcosUri").get
-    val packagesUri = systemProperty("com.mesosphere.cosmos.packageStorageUri").get
-    val stagedPackagesUri = systemProperty("com.mesosphere.cosmos.stagedPackageStorageUri").get
+    val propertiesMap = additionalProperties.map { testProperty =>
+      testProperty -> systemProperty(testProperty.propertyName).get
+    }
 
     val uriKey = "uri"
-    val packageStorageClient = "PackageStorageClient"
     setClientProperty("CosmosClient", uriKey, "http://localhost:7070")
     setClientProperty("ZooKeeperClient", uriKey, zkUri)
-    setClientProperty(packageStorageClient, "packagesUri", packagesUri)
-    setClientProperty(packageStorageClient, "stagedUri", stagedPackagesUri)
+
+    propertiesMap.foreach { case (testProperty, value) =>
+      setClientProperty(testProperty.clientName, testProperty.clientKey, value)
+    }
 
     val pathSeparator = System.getProperty("path.separator")
     val classpath =
@@ -91,10 +94,8 @@ final class CosmosIntegrationTestServer(
       classpath,
       "com.simontuffs.onejar.Boot",
       s"-com.mesosphere.cosmos.zookeeperUri=$zkUri",
-      s"-com.mesosphere.cosmos.dcosUri=$dcosUri",
-      s"-com.mesosphere.cosmos.packageStorageUri=$packagesUri",
-      s"-com.mesosphere.cosmos.stagedPackageStorageUri=$stagedPackagesUri"
-    )
+      s"-com.mesosphere.cosmos.dcosUri=$dcosUri"
+    ) ++ propertiesMap.map { case (testProperty, value) => s"-${testProperty.propertyName}=$value" }
   }
 
   def initZkCluster(logger: Logger): Unit = {

--- a/src/main/scala/com/mesosphere/cosmos/CosmosIntegrationTestServer.scala
+++ b/src/main/scala/com/mesosphere/cosmos/CosmosIntegrationTestServer.scala
@@ -79,7 +79,7 @@ final class CosmosIntegrationTestServer(
     setClientProperty("ZooKeeperClient", uriKey, zkUri)
 
     propertiesMap.foreach { case (testProperty, value) =>
-      setClientProperty(testProperty.clientName, testProperty.clientKey, value)
+      setClientProperty(testProperty.clientName, testProperty.name, value)
     }
 
     val pathSeparator = System.getProperty("path.separator")

--- a/src/main/scala/com/mesosphere/cosmos/TestProperty.scala
+++ b/src/main/scala/com/mesosphere/cosmos/TestProperty.scala
@@ -1,0 +1,15 @@
+package com.mesosphere.cosmos
+
+/**
+ * Specifies how to wire a system property into both the server under test and the test client.
+ *
+ * @param name - the short name of the system property. The full name has "com.mesosphere.cosmos"
+ *             prepended.
+ * @param clientName - the name of the test client that makes use of the property value.
+ * @param clientKey - the unique name that the test client will use to reference this property.
+ */
+case class TestProperty(name: String, clientName: String, clientKey: String) {
+
+  def propertyName: String = s"com.mesosphere.cosmos.$name"
+
+}

--- a/src/main/scala/com/mesosphere/cosmos/TestProperty.scala
+++ b/src/main/scala/com/mesosphere/cosmos/TestProperty.scala
@@ -3,12 +3,11 @@ package com.mesosphere.cosmos
 /**
  * Specifies how to wire a system property into both the server under test and the test client.
  *
+ * @param clientName - the name of the test client that makes use of the property value.
  * @param name - the short name of the system property. The full name has "com.mesosphere.cosmos"
  *             prepended.
- * @param clientName - the name of the test client that makes use of the property value.
- * @param clientKey - the unique name that the test client will use to reference this property.
  */
-case class TestProperty(name: String, clientName: String, clientKey: String) {
+case class TestProperty(clientName: String, name: String) {
 
   def propertyName: String = s"com.mesosphere.cosmos.$name"
 

--- a/src/main/scala/com/mesosphere/sbt/BuildPlugin.scala
+++ b/src/main/scala/com/mesosphere/sbt/BuildPlugin.scala
@@ -2,6 +2,7 @@ package com.mesosphere.sbt
 
 import com.github.retronym.SbtOneJar._
 import com.mesosphere.cosmos.CosmosIntegrationTestServer
+import com.mesosphere.cosmos.TestProperty
 import sbt._
 import sbt.Keys._
 import scala.Ordering.Implicits._
@@ -102,11 +103,16 @@ object BuildPlugin extends AutoPlugin {
     javaHomeValue: Option[File],
     classpathPrefix: Seq[File],
     oneJarValue: File,
+    additionalProperties: List[TestProperty],
     streamsValue: Keys.TaskStreams
   ): Seq[TestOption] = {
     val canonicalJavaHome = javaHomeValue.map(_.getCanonicalPath)
-    lazy val itServer =
-      new CosmosIntegrationTestServer(canonicalJavaHome, classpathPrefix, oneJarValue)
+    lazy val itServer = new CosmosIntegrationTestServer(
+      canonicalJavaHome,
+      classpathPrefix,
+      oneJarValue,
+      additionalProperties
+    )
 
     Seq(
       Tests.Setup(() => itServer.setup(streamsValue.log)),


### PR DESCRIPTION
Addresses [DCOS-16530](https://jira.mesosphere.com/browse/DCOS-16530).

This change allows downstream projects to specify which system properties they expect to be defined when running Cosmos integration tests, by providing a `List[TestProperty]` to `BuildPlugin.itTestOptions()`.